### PR TITLE
Add JSON-RPC protocol definitions with tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -162,6 +162,8 @@ pub fn dispatch(cli: Cli) {
                 let enforcement_mode = match app_cfg.irl.enforcement_mode.to_lowercase().as_str() {
                     "active" => EnforcementMode::Active,
                     "strict" => EnforcementMode::Strict,
+                    _ => EnforcementMode::Passive,
+                };
 
                 let runtime_cfg = RuntimeIRLConfig {
                     active_model: app_cfg.irl.active_model.clone(),
@@ -184,7 +186,8 @@ pub fn dispatch(cli: Cli) {
                 }
                 if app_cfg.irl.explanation_enabled {
                     runtime.enable_explanation();
-           // Telemetry and explanation enabling is now handled by the runtime constructor.
+                }
+                // Telemetry and explanation enabling is now handled by the runtime constructor.
 
                 Ok(Arc::new(RwLock::new(runtime)))
             };

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,10 +1,9 @@
-//! Placeholder module for protocol buffer or API schemas.
-//! Required for P0 clean build. All interfaces must justify themselves under Rule Zero.
+//! RPC and protocol buffer schema definitions.
+//!
+//! Currently this module exposes a minimal [JSON-RPC 2.0](https://www.jsonrpc.org/)
+//! interface used for communication between Sigil components. Additional
+//! protocol types may be added in the future as requirements expand.
 
 pub mod rpc;
 
-/// Reminder: No protocol logic is implemented yet.
-/// RPC calls must be audited and wrapped in ReasoningChain when implemented.
-pub fn placeholder() {
-    // This function exists to satisfy the module structure
-}
+pub use rpc::{RpcError, RpcRequest, RpcResponse};

--- a/src/proto/rpc.rs
+++ b/src/proto/rpc.rs
@@ -1,6 +1,123 @@
-//! RPC protocol definitions for Sigil
-//! This module contains the protocol buffer or JSON-RPC definitions
+//! RPC protocol definitions for Sigil.
+//!
+//! This module implements a minimal [JSON-RPC 2.0](https://www.jsonrpc.org/specification)
+//! schema using `serde` for serialization. The data structures are shared by
+//! both clients and servers to ensure compatibility.
+//!
+//! # Examples
+//!
+//! ```
+//! use mmf_sigil::proto::rpc::{RpcRequest, RpcResponse};
+//! use serde_json::json;
+//!
+//! let request = RpcRequest {
+//!     jsonrpc: "2.0".into(),
+//!    method: "ping".into(),
+//!     params: Some(json!(["hello"])),
+//!     id: Some(json!(1)),
+//! };
+//! let serialized = serde_json::to_string(&request).unwrap();
+//! assert_eq!(serialized, r#"{"jsonrpc":"2.0","method":"ping","params":["hello"],"id":1}"#);
+//! let round_trip: RpcRequest = serde_json::from_str(&serialized).unwrap();
+//! assert_eq!(round_trip, request);
+//!
+//! let response = RpcResponse {
+//!     jsonrpc: "2.0".into(),
+//!     result: Some(json!("pong")),
+//!     error: None,
+//!     id: Some(json!(1)),
+//! };
+//! let serialized = serde_json::to_string(&response).unwrap();
+//! assert_eq!(serialized, r#"{"jsonrpc":"2.0","result":"pong","id":1}"#);
+//! let round_trip: RpcResponse = serde_json::from_str(&serialized).unwrap();
+//! assert_eq!(round_trip, response);
+//! ```
+//!
+//! The tests in this module perform similar round‑trip checks to guard against
+//! schema regressions.
 
-pub fn placeholder() {
-    // This function exists to satisfy the module structure
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A JSON-RPC request message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcRequest {
+    /// JSON-RPC protocol version. Should always be "2.0".
+    pub jsonrpc: String,
+    /// The method to invoke on the server.
+    pub method: String,
+    /// Optional parameters for the method.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+    /// Identifier established by the client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+}
+
+/// A JSON-RPC response message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcResponse {
+    /// JSON-RPC protocol version. Should always be "2.0".
+    pub jsonrpc: String,
+    /// Result returned on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// Error information if the call failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+    /// Identifier from the corresponding request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+}
+
+/// Details about a JSON-RPC error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcError {
+    /// Error code as defined by the JSON-RPC spec.
+    pub code: i32,
+    /// A short description of the error.
+    pub message: String,
+    /// Additional data describing the error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn request_round_trip() {
+        let request = RpcRequest {
+            jsonrpc: "2.0".into(),
+            method: "ping".into(),
+            params: Some(json!(["hello"])),
+            id: Some(json!(1)),
+        };
+        let serialized = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"jsonrpc":"2.0","method":"ping","params":["hello"],"id":1}"#
+        );
+        let deserialized: RpcRequest = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, request);
+    }
+
+    #[test]
+    fn response_round_trip() {
+        let response = RpcResponse {
+            jsonrpc: "2.0".into(),
+            result: Some(json!("pong")),
+            error: None,
+            id: Some(json!(1)),
+        };
+        let serialized = serde_json::to_string(&response).unwrap();
+        assert_eq!(serialized, r#"{"jsonrpc":"2.0","result":"pong","id":1}"#);
+        let deserialized: RpcResponse = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, response);
+    }
 }


### PR DESCRIPTION
## Summary
- replace proto placeholder with JSON-RPC 2.0 request/response/error structs
- re-export protocol types in proto module with documentation
- add round-trip tests for schema serialization compatibility
- fix CLI enforcement-mode match and close remaining blocks

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e798b5dc832e8b5c79fadb9f0a2c