### PR TITLE
Add policy-based TrustGuard scoring with tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,7 +157,8 @@ pub fn dispatch(cli: Cli) {
                     use std::sync::Mutex;
 
                     // Load app config (mmf.toml and MMF_* env)
-                    let app_cfg = load_config();
+                    let app_cfg =
+                        load_config().map_err(|e| format!("Failed to load config: {e}"))?;
 
                     // Map loader IRL config → runtime IRL config
                     let enforcement_mode =
@@ -330,7 +331,7 @@ pub fn dispatch(cli: Cli) {
         } => {
             // Find the key file in secure locations
             let key_path = match find_key_file(&key_id) {
-                Some path) => path,
+                Some(path) => path,
                 None => {
                     eprintln!("❌ Key file not found: {key_id}.json");
                     eprintln!("   Searched in: current directory and secure key directory");

--- a/src/irl_runtime.rs
+++ b/src/irl_runtime.rs
@@ -1,18 +1,26 @@
 use crate::audit_chain::IRLInfo;
+use crate::policy_model::PolicyModel;
 
 /// TrustGuard is responsible for scoring runtime actions using IRL-derived policies.
 /// Under Rule Zero, it must emit a transparent trust score and justification for every decision.
 pub struct TrustGuard;
 
 impl TrustGuard {
-    /// Scores an action or suggestion in terms of trustworthiness.
-    /// For now, returns a fixed placeholder score.
-    pub fn score_action(_context: &str, _input: &str) -> IRLInfo {
-        // Future: plug into trained policy model and feature extractors
+    /// Scores an action or suggestion in terms of trustworthiness by
+    /// delegating to a policy model. The returned [`IRLInfo`] includes the
+    /// model identifier, a dynamic score, and the `allowed` decision so the
+    /// evaluation can be audited later.
+    pub fn score_action(context: &str, input: &str) -> IRLInfo {
+        let (model_id, score, allowed) = PolicyModel::evaluate(context, input);
+        // Emit an audit-friendly trace of the decision path.
+        println!(
+            "TrustGuard::score_action model={} score={:.2} allowed={}",
+            model_id, score, allowed
+        );
         IRLInfo {
-            model_id: "sigil_trust_v1".to_string(),
-            score: 0.0, // Default to zero until real model is integrated
-            allowed: false,
+            model_id,
+            score,
+            allowed,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod audit_store;
 pub mod audit_verifier;
 pub mod elevation_verifier;
 pub mod loa;
+pub mod policy_model;
 pub mod trust_registry;
 pub mod trusted_knowledge;
 

--- a/src/policy_model.rs
+++ b/src/policy_model.rs
@@ -1,0 +1,31 @@
+/// A simple policy model used by TrustGuard.
+/// In a production system this would call a trained model loaded from the
+/// `models/` directory. For this example we use lightweight keyword checks
+/// to produce a deterministic trust score.
+///
+/// The returned tuple contains `(model_id, score, allowed)` where:
+/// - `model_id` identifies the policy or model used for scoring.
+/// - `score` is a floating point trust score between 0.0 and 1.0.
+/// - `allowed` is derived from the score and indicates if the action is
+///   considered trustworthy.
+pub struct PolicyModel;
+
+impl PolicyModel {
+    /// Evaluates the provided context and input and produces a trust score
+    /// along with a boolean decision. The logic here is intentionally simple
+    /// so that it can be audited easily.
+    pub fn evaluate(context: &str, input: &str) -> (String, f32, bool) {
+        let combined = format!("{} {}", context, input).to_lowercase();
+        // Basic keyword based policy for demonstration purposes.
+        let score = if combined.contains("hack") || combined.contains("deny") {
+            0.0
+        } else if combined.contains("allow") || combined.contains("hello") {
+            0.9
+        } else {
+            0.5
+        };
+
+        let allowed = score >= 0.5;
+        ("rule_based_v1".to_string(), score, allowed)
+    }
+}

--- a/tests/trustguard.rs
+++ b/tests/trustguard.rs
@@ -1,0 +1,17 @@
+use mmf_sigil::irl_runtime::TrustGuard;
+
+#[test]
+fn trustguard_allows_benign_input() {
+    let info = TrustGuard::score_action("greeting", "say hello");
+    assert!(info.score >= 0.5);
+    assert!(info.allowed);
+    assert_eq!(info.model_id, "rule_based_v1");
+}
+
+#[test]
+fn trustguard_denies_risky_input() {
+    let info = TrustGuard::score_action("malicious", "attempt to hack server");
+    assert!(info.score < 0.5);
+    assert!(!info.allowed);
+    assert_eq!(info.model_id, "rule_based_v1");
+}


### PR DESCRIPTION
## Summary
- add `PolicyModel` for auditable trust scoring
- delegate `TrustGuard::score_action` to policy model and expose model metadata
- add unit tests for safe vs risky inputs
- fix CLI config loading and key lookup issues

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e79a2e88832e8a698f11a1862a02