### PR TITLE
Add extension registration with validation and CLI/API support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,14 @@ pub enum Commands {
     /// Display current LOA identity
     Whoami,
 
+    /// Register an extension module with the runtime
+    RegisterExtension {
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        loa: String,
+    },
+
     /// Serve the HTTP API (trust routes, health, versioned endpoints)
     Serve {
         /// Host/IP to bind
@@ -143,6 +151,11 @@ pub fn dispatch(cli: Cli) {
             Ok(loa) => println!("You are operating as {loa:?}"),
             Err(e) => eprintln!("LOA detection failed: {e}"),
         },
+        Commands::RegisterExtension { name, loa } => {
+            if let Err(e) = crate::extensions::register_extension(&name, &loa) {
+                eprintln!("Failed to register extension: {e}");
+            }
+        }
         Commands::Serve { host, port } => {
             // Build a runtime core using env/TOML-backed config
             let addr = format!("{host}:{port}");

--- a/src/sigilweb.rs
+++ b/src/sigilweb.rs
@@ -2,11 +2,11 @@ use crate::audit::AuditEvent;
 use crate::loa::LOA;
 use crate::sigil_runtime_core::SigilRuntimeCore;
 use axum::{
+    Router,
     extract::Extension,
     http::StatusCode,
     response::Json,
     routing::{get, post},
-    Router,
 };
 use log::error;
 use prometheus::{Encoder, IntCounter, Registry, TextEncoder};
@@ -33,11 +33,24 @@ pub struct TrustCheckResponse {
     error: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ExtensionRegisterRequest {
+    name: String,
+    loa: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExtensionRegisterResponse {
+    registered: bool,
+    error: Option<String>,
+}
+
 // Add trust-related routes
 pub fn add_trust_routes(router: Router, runtime: Arc<RwLock<SigilRuntimeCore>>) -> Router {
     router
         .route("/api/trust/check", post(check_trust))
         .route("/api/trust/status", get(trust_status))
+        .route("/api/extensions/register", post(register_extension_api))
         .layer(Extension(runtime))
 }
 
@@ -47,9 +60,11 @@ pub fn build_trust_router(runtime: Arc<RwLock<SigilRuntimeCore>>) -> Router {
         // current endpoints
         .route("/api/trust/check", post(check_trust))
         .route("/api/trust/status", get(trust_status))
+        .route("/api/extensions/register", post(register_extension_api))
         // versioned aliases
         .route("/v1/trust/check", post(check_trust))
         .route("/v1/trust/status", get(trust_status))
+        .route("/v1/extensions/register", post(register_extension_api))
         // backward-compatible aliases used by some tests
         .route("/trust/check", post(check_trust))
         .route("/trust/status", get(trust_status))
@@ -121,6 +136,22 @@ async fn check_trust(
         threshold,
         error,
     }))
+}
+
+#[axum::debug_handler]
+async fn register_extension_api(
+    Json(req): Json<ExtensionRegisterRequest>,
+) -> Result<Json<ExtensionRegisterResponse>, (StatusCode, String)> {
+    match crate::extensions::register_extension(&req.name, &req.loa) {
+        Ok(_) => Ok(Json(ExtensionRegisterResponse {
+            registered: true,
+            error: None,
+        })),
+        Err(e) => {
+            error!("Extension registration failed for {}: {}", req.name, e);
+            Err((StatusCode::BAD_REQUEST, e))
+        }
+    }
 }
 
 #[axum::debug_handler]


### PR DESCRIPTION
## Summary
- track registered extensions with required LOA and canon validation
- add CLI `RegisterExtension` command and HTTP endpoint to register modules
- use OS entropy for key generation to resolve build issues

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3bfe2718832e9afd73a7b18f2a49